### PR TITLE
Remove Dataset Operator From Deployment Pipeline

### DIFF
--- a/pipelines/deployment.py
+++ b/pipelines/deployment.py
@@ -28,12 +28,7 @@ def create_deployment(deployment_id, pipeline_parameters):
             name = pipeline_parameters['name']
         operators = pipeline_parameters['operators']
 
-        non_deployable_operators = list()
-        for operator in operators:
-            if operator["notebookPath"] is None:
-                non_deployable_operators.append(operator["operatorId"])
-
-        operators = remove_non_deployable_operators(non_deployable_operators, operators)
+        operators = remove_non_deployable_operators(operators)
 
     except KeyError as e:
         raise BadRequest(

--- a/pipelines/deployment.py
+++ b/pipelines/deployment.py
@@ -8,7 +8,8 @@ from kubernetes.client.rest import ApiException
 from kubernetes import client
 from werkzeug.exceptions import BadRequest, NotFound
 
-from .utils import load_kube_config, init_pipeline_client, format_deployment_pipeline, get_cluster_ip
+from .utils import load_kube_config, init_pipeline_client, format_deployment_pipeline, get_cluster_ip,\
+    remove_non_deployable_operators
 from .pipeline import Pipeline
 
 
@@ -26,6 +27,14 @@ def create_deployment(deployment_id, pipeline_parameters):
         if 'name' in pipeline_parameters:
             name = pipeline_parameters['name']
         operators = pipeline_parameters['operators']
+
+        non_deployable_operators = list()
+        for operator in operators:
+            if operator["notebookPath"] is None:
+                non_deployable_operators.append(operator["operatorId"])
+
+        operators = remove_non_deployable_operators(non_deployable_operators, operators)
+
     except KeyError as e:
         raise BadRequest(
             'Invalid request body, missing the parameter: {}'.format(e)

--- a/pipelines/operator.py
+++ b/pipelines/operator.py
@@ -29,7 +29,11 @@ class Operator():
         self._experiment_id = experiment_id
         self._dataset = dataset
         self._operator_id = operator_id
-        self._notebook_path = validate_notebook_path(notebook_path)
+
+        if notebook_path:
+            self._notebook_path = validate_notebook_path(notebook_path)
+        else:
+            self._notebook_path = None
 
         self._parameters = parameters
         self.container_op = None


### PR DESCRIPTION
- when deploying an experiment, remove all operators that do not belong to the deployment pipeline (i.e. operators that do not contain notebookPath);
- remove (if any), from the operators belonging to the deployment pipeline, the dependencies that do not belong to the flow;