### PR TITLE
Reads Kubeflow pipelines namespace from env variable

### DIFF
--- a/pipelines/controllers/operator.py
+++ b/pipelines/controllers/operator.py
@@ -2,6 +2,7 @@
 import base64
 import yaml
 import json
+import os
 from json import dumps
 from string import Template
 
@@ -11,6 +12,8 @@ from kubernetes import client as k8s_client
 from ..resources.templates import COMPONENT_SPEC, GRAPH, LOGGER, \
     POD_DEPLOYMENT, POD_DEPLOYMENT_VOLUME
 from .utils import TRAINING_DATASETS_DIR, check_pvc_is_bound, validate_notebook_path
+
+KF_PIPELINES_NAMESPACE = os.getenv('KF_PIPELINES_NAMESPACE', 'deployments')
 
 
 class Operator():
@@ -157,7 +160,7 @@ class Operator():
 
     def build_operator(self):
         volume_spec = POD_DEPLOYMENT_VOLUME.substitute({
-            "namespace": "deployments",
+            "namespace": KF_PIPELINES_NAMESPACE,
             'operatorId': self._operator_id,
         })
         dsl.ResourceOp(
@@ -165,7 +168,7 @@ class Operator():
             k8s_resource=json.loads(volume_spec)
         )
         operator_spec = POD_DEPLOYMENT.substitute({
-            "namespace": "deployments",
+            "namespace": KF_PIPELINES_NAMESPACE,
             'notebookPath': self._notebook_path,
             'status': "$?",
             'experimentId': self._experiment_id,

--- a/pipelines/controllers/pipeline.py
+++ b/pipelines/controllers/pipeline.py
@@ -13,6 +13,7 @@ from .operator import Operator
 
 from kubernetes.client.models import V1PersistentVolumeClaim
 
+KF_PIPELINES_NAMESPACE = getenv('KF_PIPELINES_NAMESPACE', 'deployments')
 MEMORY_REQUEST = getenv('MEMORY_REQUEST', '2G')
 MEMORY_LIMIT = getenv('MEMORY_LIMIT', '4G')
 CPU_REQUEST = getenv('CPU_REQUEST', '500m')
@@ -215,7 +216,7 @@ class Pipeline():
                 kind="PersistentVolumeClaim",
                 metadata={
                     'name': f'vol-{self._experiment_id}',
-                    'namespace': 'deployments'
+                    'namespace': KF_PIPELINES_NAMESPACE,
                 },
                 spec={
                     'accessModes': ['ReadWriteOnce'],
@@ -265,7 +266,7 @@ class Pipeline():
         @dsl.pipeline(name='Common Seldon Deployment.')
         def deployment_pipeline():
             seldonserving = SELDON_DEPLOYMENT.substitute({
-                "namespace": "deployments",
+                "namespace": KF_PIPELINES_NAMESPACE,
                 "experimentId": self._experiment_id,
                 "deploymentName": self._name,
                 "componentSpecs": operator_specs,

--- a/pipelines/controllers/utils.py
+++ b/pipelines/controllers/utils.py
@@ -28,7 +28,8 @@ def init_pipeline_client():
     Returns:
         An instance of kfp client.
     """
-    return Client(getenv("KF_PIPELINES_ENDPOINT", '0.0.0.0:31380/pipeline'), namespace="deployments")
+    return Client(host=getenv('KF_PIPELINES_ENDPOINT', '0.0.0.0:31380/pipeline'),
+                  namespace=getenv('KF_PIPELINES_NAMESPACE', 'deployments'))
 
 
 def load_kube_config():


### PR DESCRIPTION
If value is not set, uses 'deployments' as default.
This is a necessary config. since the namespace is created using
manifests (yaml), and a hard-coded value would not allow changes
in manifests to work 100%.